### PR TITLE
[bi-366] Adding new data description

### DIFF
--- a/filing_history_descriptions.yml
+++ b/filing_history_descriptions.yml
@@ -1037,3 +1037,4 @@ description:
     'registration-of-a-limited-partnership' : "**Registration** of a Limited Partnership"
     'registration-of-a-scottish-partnership' : "**Registration** of a Scottish Partnership"
     'notice-of-ceasing-to-be-a-qualifying-partnership' : "**Notice of ceasing** to be a qualifying partnership"
+    'appoint-corporate-manager-european-economic-interest-groupings' : "**Appointment** of corporate EEIG manager"


### PR DESCRIPTION
This change has been made to show the EEAP02 transaction on CHS. 
1.  **api-enumerations:** 
Added a new transaction description for EEAP02
https://github.com/companieshouse/api-enumerations/pull/102

1. **chs-backend**
Changes to show EEAP02 on CHS (added: data.type, data.category, data.subcategory, data.description, original_description)
Added test for this change
https://github.com/companieshouse/chs-backend/pull/668

1. **Updating submodules using api-enumerations:** 
- chs-monitor-notification-matcher: https://github.com/companieshouse/chs-monitor-notification-matcher/pull/39
- accounts.api.ch.gov.uk: https://github.com/companieshouse/accounts.api.ch.gov.uk/pull/237
- api.ch.gov.uk: https://github.com/companieshouse/api.ch.gov.uk/pull/453
- ch.gov.uk: https://github.com/companieshouse/ch.gov.uk/pull/798
- document-generator-accounts: https://github.com/companieshouse/document-generator-accounts/pull/40
