### PR TITLE
[si-391][si-392] Adding new mappings for FE companies

### DIFF
--- a/constants.yml
+++ b/constants.yml
@@ -42,7 +42,7 @@ company_summary:
     'scottish-partnership' : "Scottish qualifying partnership"
     'charitable-incorporated-organisation' : "Charitable incorporated organisation"
     'scottish-charitable-incorporated-organisation' : "Scottish charitable incorporated organisation"
-    'further-education-corporation-or-sixth-form-college' : "Further Education Corporation or Sixth Form College"
+    'further-education-or-sixth-form-college-corporation' : "Further education or sixth form college corporation"
 company_type:
     'private-unlimited' : "Private unlimited company"
     'ltd' : "Private limited company"
@@ -75,7 +75,7 @@ company_type:
     'scottish-partnership' : "Scottish qualifying partnership"
     'charitable-incorporated-organisation' : "Charitable incorporated organisation"
     'scottish-charitable-incorporated-organisation' : "Scottish charitable incorporated organisation"
-    'further-education-corporation-or-sixth-form-college' : "Further Education Corporation or Sixth Form College"
+    'further-education-or-sixth-form-college-corporation' : "Further education or sixth form college corporation"
 company_subtype:
     'community-interest-company' : "Community Interest Company (CIC)"
     'private-fund-limited-partnership' : "Private Fund Limited Partnership (PFLP)"
@@ -107,7 +107,7 @@ company_birth_type:
     'european-public-limited-liability-company-se' : "Formed on"
     'uk-establishment' : "Opened on"
     'scottish-partnership' : "Registered on"
-    'further-education-corporation-or-sixth-form-college' : "Published on"
+    'further-education-corporation-or-sixth-form-college' : "Registered on"
 proof_status:
     'paper' : "PAPER"
     'electronic' : "ELECTRONIC"

--- a/constants.yml
+++ b/constants.yml
@@ -107,7 +107,7 @@ company_birth_type:
     'european-public-limited-liability-company-se' : "Formed on"
     'uk-establishment' : "Opened on"
     'scottish-partnership' : "Registered on"
-    'further-education-corporation-or-sixth-form-college' : "Registered on"
+    'further-education-or-sixth-form-college-corporation' : "Registered on"
 proof_status:
     'paper' : "PAPER"
     'electronic' : "ELECTRONIC"

--- a/filing_history_descriptions.yml
+++ b/filing_history_descriptions.yml
@@ -1047,4 +1047,4 @@ description:
     'selection-of-documents-registered-before-January-1995' : "A selection of documents registered before 1 January 1995"
     'selection-of-mortgage-documents-registered-before-January-1995' : "A selection of mortgage documents registered before 1 January 1995"
     'selection-of-documents-registered-before-April-2014' : "A selection of documents registered before 5 April 2014"
-    'notice-of-insolvency-proceedings-for-a-further-education-or-sixth-form-college-corporation' : "Notice of insolvency proceedings for a further education or sixth form college corporation"
+    'notice-of-insolvency-proceedings-for-a-further-education-or-sixth-form-college-corporation' : "**Notice of insolvency proceedings** for a further education or sixth form college corporation"

--- a/filing_history_descriptions.yml
+++ b/filing_history_descriptions.yml
@@ -1047,4 +1047,4 @@ description:
     'selection-of-documents-registered-before-January-1995' : "A selection of documents registered before 1 January 1995"
     'selection-of-mortgage-documents-registered-before-January-1995' : "A selection of mortgage documents registered before 1 January 1995"
     'selection-of-documents-registered-before-April-2014' : "A selection of documents registered before 5 April 2014"
-    'notice-of-details-of-a-further-education-corporation-or-sixth-form-college' : "Notice of details of a Further Education Corporation or Sixth form college insolvency"
+    'notice-of-insolvency-proceedings-for-a-further-education-or-sixth-form-college-corporation' : "Notice of insolvency proceedings for a further education or sixth form college corporation"


### PR DESCRIPTION
This change has been made to both show the FE01 and new corporate body type (33) on CHS
__SI-391__
__SI-392__

**chs-backend**
Changes to show FE01 transaction correctly on CHS (new data.type FE01 added. data.type accompanied by data.category and data.description)
Changes to add new corporate body type (33) to company profile enums to show correctly on company profile
Tests written and passing.
https://github.com/companieshouse/chs-backend/pull/727

**api-enumerations:**
Added a new filing history description for FE01 as described in __si-391__
Added new constants for the FE corporate body type (33) as described in __si-392__
https://github.com/companieshouse/api-enumerations/pull/123

**Updating submodules using api-enumerations:**

abridged.accounts.api.ch.gov.uk: https://github.com/companieshouse/abridged.accounts.api.ch.gov.uk/pull/397
roa.api.ch.gov.uk: https://github.com/companieshouse/roa.api.ch.gov.uk/pull/25
document-generator-accounts: https://github.com/companieshouse/document-generator-accounts/pull/72
ch-android-app: https://github.com/companieshouse/ch-android-app/pull/50
api.ch.gov.uk: https://github.com/companieshouse/api.ch.gov.uk/pull/506
chs-monitor-notification-matcher: https://github.com/companieshouse/chs-monitor-notification-matcher/pull/60
document-generator/tree/develop/document-generator-api: https://github.com/companieshouse/document-generator/pull/81
ch.gov.uk: https://github.com/companieshouse/ch.gov.uk/pull/31