### PR TITLE
PCI-505: Use underscore, not hyphen in substitution variable name.

### DIFF
--- a/orders_descriptions.yaml
+++ b/orders_descriptions.yaml
@@ -1,3 +1,3 @@
 ---
 certificate-description:
-  'company-certificate' : 'certificate for company {company-number}'
+  'company-certificate' : 'certificate for company {company_number}'


### PR DESCRIPTION
This is in line with other api-enumerations YAML resource files and makes it easier to ensure that underscores are used in the keys in JSON too.