### PR TITLE
Change description identifier key for S9B

### DIFF
--- a/disqualified_officer_descriptions.yml
+++ b/disqualified_officer_descriptions.yml
@@ -10,6 +10,7 @@ description_identifier:
     'matters-determining-unfitness-of-directors' : "Matters for determining unfitness of directors"
     'competition-infringements' : "Disqualification for competition infringements"
     'undertaking-for-competition' : "Disqualification undertaking for competition"
+    'competition-and-markets-authority-disqualification-undertaking' : "Competition and Markets Authority Disqualification Undertaking"
     'participation-in-wrongful-trading' : "Participation in wrongful trading"
     'conviction-of-offence-punishable-on-indictment-or-conviction-on-indictment-or-summary-conviction' : "Disqualification on conviction of offence punishable only on indictment or either on conviction on indictment or on summary conviction"
     'persistent-default-under-companies-legislation' : "Disqualification for persistent default under companies legislation"


### PR DESCRIPTION
Change\Add description identifier key for S9B and A13B

Resolves part of:
- [BI-9659](https://companieshouse.atlassian.net/browse/BI-9659) and
- [BI-9697](https://companieshouse.atlassian.net/browse/BI-9697)