### PR TITLE
ROE-66: Search description date mappings for registered and removed ROEs

### DIFF
--- a/search_descriptions_raw.yaml
+++ b/search_descriptions_raw.yaml
@@ -14,6 +14,8 @@ company_search_description:
     'liquidation' : "Liquidation"
     'administration' : "In Administration"
     'registered-externally' : "Registered externally as {external_registration_number}"
+    'registered' : "Registered on {date:date_of_creation}"
+    'removed': "Removed on {date:date_of_cessation}"
 officer_search_description:
     'appointment-count' : "Total number of appointments {appointment_count}"
     'born-on' : "Born {month-year:date_of_birth}"

--- a/search_descriptions_raw.yaml
+++ b/search_descriptions_raw.yaml
@@ -15,7 +15,7 @@ company_search_description:
     'administration' : "In Administration"
     'registered-externally' : "Registered externally as {external_registration_number}"
     'registered' : "Registered on {date:date_of_creation}"
-    'removed': "Removed on {date:date_of_cessation}"
+    'removed' : "Removed on {date:date_of_cessation}"
 officer_search_description:
     'appointment-count' : "Total number of appointments {appointment_count}"
     'born-on' : "Born {month-year:date_of_birth}"


### PR DESCRIPTION
* Adding these mappings means `api.ch.gov.uk` will render the relevant ROE date correctly before it is handed over to `ch.gov.uk` for display in primary search results. 