### PR TITLE
Add moratorium to list of insolvency case types

### DIFF
--- a/constants.yml
+++ b/constants.yml
@@ -240,6 +240,7 @@ insolvency_case_type:
     'liquidation-moratorium-court-order-permitting-disposal-of-goods' : "Court order permitting disposal of property or goods"
     'liquidation-moratorium-replacement-or-additonal-monitor-following-court-order' : "Replacement or additional monitor (following court order)"
     'liquidation-moratorium-monitor-ceasing-to-act-following-court-order' : "Monitor ceasing to act following court"
+    'moratorium' : "Moratorium"
 insolvency_case_date_type:
     'wound-up-on' : "Commencement of winding up"
     'petitioned-on' : "Petition date"


### PR DESCRIPTION
This pr adds moratorium to the list of insolvency case types. This fixes a bug causing the case type to appear blank for moratorium case in chs.

**Resolves:**
- DSND-994

**Related pr**
ch.gov.uk - https://github.com/companieshouse/ch.gov.uk/pull/342