### PR TITLE
Add legacy filing description format

### DIFF
--- a/filing_history_descriptions.yml
+++ b/filing_history_descriptions.yml
@@ -1110,3 +1110,4 @@ description:
     'removal-overseas-entity' : "**Removal** of an overseas entity"
     'annual-update-with-made-up-date' : "**Annual update** made on {made_up_date}"
     'annual-update' : "{original_description}"
+    'legacy': "{description}"


### PR DESCRIPTION
Legacy filing descriptions have the description in `description_values.description`, so this format shows the description.

Otherwise if you do a lookup on description in this object it can't find a match. 

By adding this, it will solve the problem.