### PR TITLE
Amend PSC Filing validation message

### DIFF
--- a/psc_filing.yml
+++ b/psc_filing.yml
@@ -11,7 +11,7 @@ validation:
     'reference-psc-id-missing' : "Reference PSC ID must be entered"
     'reference-etag-missing' : "Reference ETag must be entered"
     'super-secure-company' : "A PSC for this company has details protected. You can only file for this company on paper"
-    'company-type-not-allowed' : "This filing cannot be submitted for a "
+    'company-type-not-allowed' : "This filing cannot be submitted by this company type"
     'company-status-not-allowed' : "You cannot submit a filing for a company that is "
 
 company:


### PR DESCRIPTION
- makes more consistent with officer filing
- avoids trying to determine use of 'a' or 'an'

PSC-190