### PR TITLE
Web messages added

### DIFF
--- a/officer_filing.yml
+++ b/officer_filing.yml
@@ -16,3 +16,10 @@ validation:
   'etag-invalid' : "The Director’s information was updated before you sent this submission. You will need to start again"
   'etag-blank' : "ETag must be completed"
   'officer-id-blank' : "The Officer ID must be completed"
+validation_web:
+  'removal-date-in-past' : "Enter a date that is in the past"
+  'removal-date-missing' : "Date director was removed must be a real date"
+  'removal-date-after-appointment-date' : "Enter a date that is on or after the date the director was appointed"
+  'removal-date-invalid' : "Date director was removed must be a real date"
+  'removal-date-after-incorporation-date' : "Enter a date that is on or after the company's incorporation date"
+  'removal-date-after-2009' : "Enter a date that is on or after 1 October 2009. If the director was removed before this date, you must file form 288b instead"


### PR DESCRIPTION
Original Context

The 'When was the Director removed from the company?' page is the 7th page in the happy path journey for the web service. It acts as a page where an Officer may enter a date when the director was removed from a company. An Officer should be able to;

Click the ‘continue’ button to move to the 'Check your answers before submitting the removal of a director' page.

Web messages needed to be displayed to the user.