### PR TITLE
DACT-712-Amend-Past-Error-Message

### DIFF
--- a/officer_filing.yml
+++ b/officer_filing.yml
@@ -42,7 +42,7 @@ validation_web:
   "removal-date-missing-month-year" : "Date the director was removed must include a month and a year"
   "removal-date-missing-day-month-year" : "Enter the date the director was removed"
   "removal-date-invalid" : "Date the director was removed must be a real date"
-  'removal-date-in-past' : "Enter a date that is in the past"
+  'removal-date-in-past' : "Enter a date that is today or in the past"
   'removal-date-after-appointment-date' : "Enter a date that is on or after the date the director was appointed"
   'removal-date-after-incorporation-date' : "Enter a date that is on or after the company's incorporation date"
   'removal-date-after-2009' : "Enter a date that is on or after 1 October 2009. If the director was removed before this date, you must file form 288b instead"


### PR DESCRIPTION
Context:
When a date is entered in the future the error message should say Enter a date that is today or in the past

Replication steps:
Start on the date and remove page
Enter the date in future
Press continue

Expected Behaviour:
After creating the replication steps the error message should day ‘Enter a date that is today or in the past’