### PR TITLE
Adding error message for missing director protected details boolean

### DIFF
--- a/officer_filing.yml
+++ b/officer_filing.yml
@@ -86,6 +86,7 @@ validation:
   'residential-address-line-two-length': "Address line 2 for the director's home address must be 50 characters or less"
   'residential-region-characters': "County, state, province or region for the director's home address must only include letters a to z, and common special characters such as hyphens, spaces and apostrophes"
   'residential-region-length': "County, state, province or region for the director's home address must be 50 characters or less"
+  'protected-details-missing': "Confirm if the director has ever applied to protect their details at Companies House"
 
 validation_web:
   'removal-date-missing-day' : "Date the director was removed must include a day"


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/DACT-587
Adding error message string for API error if boolean value is not provided for "director applied to protect details"