### PR TITLE
Adding error message string for missing consent to act

### DIFF
--- a/officer_filing.yml
+++ b/officer_filing.yml
@@ -87,6 +87,7 @@ validation:
   'residential-region-characters': "County, state, province or region for the director's home address must only include letters a to z, and common special characters such as hyphens, spaces and apostrophes"
   'residential-region-length': "County, state, province or region for the director's home address must be 50 characters or less"
   'protected-details-missing': "Confirm if the director has ever applied to protect their details at Companies House"
+  'consent-to-act-missing': "Confirm that by submitting this information, the person named has consented to act as director"
 
 validation_web:
   'removal-date-missing-day' : "Date the director was removed must include a day"

--- a/officer_filing.yml
+++ b/officer_filing.yml
@@ -88,6 +88,7 @@ validation:
   'residential-region-length': "County, state, province or region for the director's home address must be 50 characters or less"
   'protected-details-missing': "Confirm if the director has ever applied to protect their details at Companies House"
   'consent-to-act-missing': "Confirm that by submitting this information, the person named has consented to act as director"
+  'consent-to-act-false': "You will not be able to continue if the person named has not consented to act as director. Confirm consent to continue."
 
 validation_web:
   'removal-date-missing-day' : "Date the director was removed must include a day"


### PR DESCRIPTION
[DACT-586](https://companieshouse.atlassian.net/browse/DACT-586)
Adding error message string for missing consent to act boolean value

[DACT-586]: https://companieshouse.atlassian.net/browse/DACT-586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ