### PR TITLE
Remove old mapping for director-disqualification-sanctions

### DIFF
--- a/disqualified_officer_descriptions.yml
+++ b/disqualified_officer_descriptions.yml
@@ -25,7 +25,6 @@ description_identifier:
     'order-disqualifying-a-person-instructing-an-unfit-director' : "Order disqualifying a person instructing an unfit director"
     'undertaking-disqualifying-a-person-instructing-an-unfit-director-of-an-insolvent-company' : "Disqualification undertaking disqualifying a person instructing an unfit director of an insolvent company"
     'undertaking-disqualifying-a-person-instructing-an-unfit-director' : "Disqualification undertaking disqualifying a person instructing an unfit director"
-    'director-disqualification-sanctions': "Director Disqualification Sanctions"
     'disqualification-under-sanctions-regulation': "Disqualification of persons designated under sanctions legislation"
 act:
     'company-directors-disqualification-act-1986' : "Company Directors Disqualification Act 1986"


### PR DESCRIPTION
Remove the old mapping of director-disqualification-sanctions as it's outdated.

Jira ticket: https://companieshouse.atlassian.net/browse/PAS-1124